### PR TITLE
Fix SQL column typo in signup script

### DIFF
--- a/wa_manager.php
+++ b/wa_manager.php
@@ -170,7 +170,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_SERVER['CONTENT_TYPE']) &&
     try {
         $ins = $pdo->prepare("
             INSERT INTO wa_accounts
-              (uaer_id, business_account_id, phone_number_id, phone_number, access_token)
+              (user_id, business_account_id, phone_number_id, phone_number, access_token)
             VALUES
               (:uid, :w, :p, :n, :t)
         ");


### PR DESCRIPTION
## Summary
- correct typo `uaer_id` -> `user_id` in `wa_manager.php`

## Testing
- `php -l wa_manager.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f43f9b6dc832e9d21e95cc4624d4a